### PR TITLE
If the computer is headless, set up virtual display

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ cd /Applications/Xcode.app/Contents/Developer/usr/bin/
 sudo ln -s xcodebuild xcrun
 ```
 
+# Running on a headless computer (a computer a graphical interface)
+phantomjs requires some graphical software, virtual or otherwise, so on a headless computer, you'll need the following system package and local package.
+If you're not using virtualenv (below) then run pip as sudo.
+```
+sudo apt-get install xvfb
+pip install pyvirtualdisplay
+```
+
 # Installation through virtualenv
 
 In order to isolate pip library files, virtualenv is convenient. If you prefer this method, you can follow the steps below:

--- a/isp_data_pollution.py
+++ b/isp_data_pollution.py
@@ -30,6 +30,13 @@ from faker import Factory
 # nice this process on UNIX
 if hasattr(os,'nice'): os.nice(15)
 
+try:
+    from pyvirtualdisplay import Display
+    display = Display(visible=0, size=(1296,1018))
+    display.start()
+except ImportError:
+    pass
+
 gb_per_month = 50		# How many gigabytes to pollute per month
 max_links_cached = 100000	# Maximum number of links to cache for download
 max_links_per_page = 200	# Maximum number of links to add per page


### PR DESCRIPTION
Documentation on pyvirtualdisplay talks about how you should close the display when you're done.

I've currently been noticing issues with 'ctrl+c' anyway, and I know python garbage collection will close the display at the end.

So I didn't bother closing the display when the connection ends, since we'd just need to start a new one each time.
Also note that the size of the display should probably match the size of the phantomjs display (at or around line 176).

I'm not sure if it makes sense to variable-ize that someplace.